### PR TITLE
fix(recipe): modernes Flex-Endpoint-Format — Recipes werden tatsächlich angewendet (closes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,22 @@ Ein Recipe-Tree wird über `manifest.json` referenziert; die Felder sind mit dem
 }
 ```
 
-Die Einträge im Top-Level-`index.json` verknüpfen Paketnamen mit einer Recipe-Version:
+### Format (wichtig): modernes Flex-Endpoint-Format, generiert via `flatten.mjs`
 
-```json
-{
-    "manifests": {
-        "smr492/auth-bundle": {
-            "manifest": { "bundles": {...}, "copy-from-recipe": {...} },
-            "origin": "smr492/auth-bundle:1.0@github.com/smr492/recipes"
-        }
-    }
-}
+> **Empirisch verifiziert (Issue #4):** Das alte flache `{"manifests": {…}}`-Format wird von Flex bei einem **konfigurierten** `extra.symfony.endpoint` **ignoriert** (Flex fällt auf eine auto-generierte Recipe zurück → nur Bundle-Registrierung, keine Config-Dateien). Ein konfigurierter Endpoint verlangt das **moderne** Format.
+
+Die `smr492/<bundle>/<version>/`-Ordner sind die **Quelle**. Der Generator `flatten.mjs` erzeugt daraus die von Flex konsumierten Dateien:
+
+- **`index.json`** — Endpoint-Index: `recipes` (Paket→Versionen) + `_links` (mit `recipe_template_relative`, branch-agnostisch) + `branch` + `is_contrib: false`.
+- **`<paket_dotted>.<version>.json`** — Per-Recipe-Manifest **inkl. `files`** (Dateiinhalte als Zeilen-Array) + `ref`.
+
+```bash
+node flatten.mjs main      # erzeugt index.json + <paket>.<version>.json aus smr492/*/*/
 ```
+
+Wichtig für Consumer:
+- **`is_contrib: false`** — eigener vertrauter Server; Flex wendet die Recipes ohne `allow-contrib`/Prompt an.
+- Recipes matchen nur **getaggte** Releases (z.B. `1.0.0`), **nicht** Dev-Branch-Installs (`dev-…`) — Flex wertet Dev-Versionen kleiner als jede numerische Recipe-Version.
 
 ## Neues Recipe hinzufügen
 
@@ -86,14 +90,8 @@ Die Einträge im Top-Level-`index.json` verknüpfen Paketnamen mit einer Recipe-
    - `copy-from-recipe` → lokale Pfade (z.B. `config/`) auf Flex-Platzhalter (`%CONFIG_DIR%/`) mappen.
    - Optional `post-install-output` für Next-Steps-Hinweise.
 3. Unter `config/packages/<bundle>.yaml` und ggf. `config/routes/<bundle>.yaml` die Host-App-Defaults ablegen.
-4. Top-Level `index.json` ergänzen:
-   ```json
-   "smr492/<bundle>": {
-       "manifest": { "bundles": { "Vendor\\Bundle\\VendorBundle": ["all"] }, "copy-from-recipe": { "config/": "%CONFIG_DIR%/" } },
-       "origin": "smr492/<bundle>:<version>@github.com/smr492/recipes"
-   }
-   ```
-5. Änderungen nach `main` mergen – der GitHub raw-Endpoint ist sofort aktiv.
+4. `node flatten.mjs main` ausführen → regeneriert `index.json` + `<paket_dotted>.<version>.json` (nicht von Hand pflegen).
+5. Änderungen nach `main` mergen – der GitHub raw-Endpoint ist sofort aktiv. Consumer ziehen die getaggte Release-Version (`composer require smr492/<bundle>:^1.0`).
 
 ## Versionsstrategie
 

--- a/flatten.mjs
+++ b/flatten.mjs
@@ -59,7 +59,9 @@ for (const vendor of VENDORS) {
 const index = {
   recipes,
   branch: BRANCH,
-  is_contrib: true,
+  // eigener, vertrauter Recipe-Server → non-contrib, damit Flex die Recipes ohne
+  // allow-contrib/Prompt automatisch anwendet (sonst „IGNORING").
+  is_contrib: false,
   _links: {
     repository: 'github.com/SmR492/recipes',
     origin_template: '{package}:{version}@github.com/SmR492/recipes',

--- a/flatten.mjs
+++ b/flatten.mjs
@@ -1,0 +1,77 @@
+// Flatten-Generator für das moderne Symfony-Flex-Endpoint-Format.
+// Liest die Recipe-Quellen unter smr492/<bundle>/<version>/ (manifest.json + Dateibaum)
+// und erzeugt:
+//   - index.json                          (recipes-Liste + _links + branch)
+//   - <package_dotted>.<version>.json      (Per-Recipe-Manifest INKL. files/ref)
+//
+// Hintergrund: Bei konfiguriertem extra.symfony.endpoint liest Flex NUR recipes/_links
+// aus dem Index und lädt Manifest+files separat (Downloader.php). Das alte flache
+// {"manifests":…} wird dann ignoriert (Issue #4).
+//
+// Aufruf: node flatten.mjs [branch]   (branch nur informativ; Auslieferung ist branch-relativ)
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { createHash } from 'node:crypto';
+
+const ROOT = process.cwd();
+const BRANCH = process.argv[2] || 'main';
+const VENDORS = readdirSync(ROOT).filter((d) => statSync(join(ROOT, d)).isDirectory() && !d.startsWith('.'));
+
+const walk = (dir) => readdirSync(dir).flatMap((e) => {
+  const p = join(dir, e);
+  return statSync(p).isDirectory() ? walk(p) : [p];
+});
+
+const recipes = {};
+const perRecipe = {};
+
+for (const vendor of VENDORS) {
+  const vendorDir = join(ROOT, vendor);
+  for (const bundle of readdirSync(vendorDir)) {
+    const bundleDir = join(vendorDir, bundle);
+    if (!statSync(bundleDir).isDirectory()) continue;
+    const pkg = `${vendor}/${bundle}`;
+    for (const version of readdirSync(bundleDir)) {
+      const verDir = join(bundleDir, version);
+      if (!statSync(verDir).isDirectory()) continue;
+      const manifestPath = join(verDir, 'manifest.json');
+      let manifest;
+      try { manifest = JSON.parse(readFileSync(manifestPath, 'utf8')); } catch { continue; }
+
+      const files = {};
+      for (const f of walk(verDir)) {
+        if (f === manifestPath) continue;
+        const rel = relative(verDir, f).split('\\').join('/');
+        files[rel] = { contents: readFileSync(f, 'utf8').split('\n'), executable: false };
+      }
+
+      (recipes[pkg] ??= []).push(version);
+      const ref = createHash('sha1').update(JSON.stringify({ manifest, files })).digest('hex').slice(0, 12);
+      const dotted = pkg.replace('/', '.');
+      perRecipe[`${dotted}.${version}.json`] = {
+        manifests: { [pkg]: { manifest, files, ref } },
+      };
+    }
+    if (recipes[pkg]) recipes[pkg].sort();
+  }
+}
+
+const index = {
+  recipes,
+  branch: BRANCH,
+  is_contrib: true,
+  _links: {
+    repository: 'github.com/SmR492/recipes',
+    origin_template: '{package}:{version}@github.com/SmR492/recipes',
+    recipe_template: `https://raw.githubusercontent.com/SmR492/recipes/${BRANCH}/{package_dotted}.{version}.json`,
+    // branch-relativ: Flex ersetzt das letzte Pfadsegment des konfigurierten Endpoints
+    // (…/<branch>/index.json) durch dieses Template → funktioniert auf main UND develop.
+    recipe_template_relative: '{package_dotted}.{version}.json',
+  },
+};
+
+writeFileSync(join(ROOT, 'index.json'), JSON.stringify(index, null, 4) + '\n');
+for (const [name, body] of Object.entries(perRecipe)) {
+  writeFileSync(join(ROOT, name), JSON.stringify(body, null, 4) + '\n');
+}
+console.log(JSON.stringify({ recipes, generated: ['index.json', ...Object.keys(perRecipe)] }, null, 2));

--- a/index.json
+++ b/index.json
@@ -1,26 +1,18 @@
 {
-    "manifests": {
-        "smr492/neuro-symbolic-ai-bundle": {
-            "manifest": {
-                "bundles": {
-                    "SmR492\\NeuroSymbolicAiBundle\\NeuroSymbolicAiBundle": ["all"]
-                },
-                "copy-from-recipe": {
-                    "config/": "%CONFIG_DIR%/"
-                }
-            },
-            "origin": "smr492/neuro-symbolic-ai-bundle:1.0@github.com/smr492/recipes"
-        },
-        "smr492/auth-bundle": {
-            "manifest": {
-                "bundles": {
-                    "Smr492\\AuthBundle\\Smr492AuthBundle": ["all"]
-                },
-                "copy-from-recipe": {
-                    "config/": "%CONFIG_DIR%/"
-                }
-            },
-            "origin": "smr492/auth-bundle:1.0@github.com/smr492/recipes"
-        }
+    "recipes": {
+        "smr492/auth-bundle": [
+            "1.0"
+        ],
+        "smr492/neuro-symbolic-ai-bundle": [
+            "1.0"
+        ]
+    },
+    "branch": "develop",
+    "is_contrib": true,
+    "_links": {
+        "repository": "github.com/SmR492/recipes",
+        "origin_template": "{package}:{version}@github.com/SmR492/recipes",
+        "recipe_template": "https://raw.githubusercontent.com/SmR492/recipes/develop/{package_dotted}.{version}.json",
+        "recipe_template_relative": "{package_dotted}.{version}.json"
     }
 }

--- a/index.json
+++ b/index.json
@@ -8,7 +8,7 @@
         ]
     },
     "branch": "develop",
-    "is_contrib": true,
+    "is_contrib": false,
     "_links": {
         "repository": "github.com/SmR492/recipes",
         "origin_template": "{package}:{version}@github.com/SmR492/recipes",

--- a/smr492.auth-bundle.1.0.json
+++ b/smr492.auth-bundle.1.0.json
@@ -1,0 +1,40 @@
+{
+    "manifests": {
+        "smr492/auth-bundle": {
+            "manifest": {
+                "bundles": {
+                    "Smr492\\AuthBundle\\Smr492AuthBundle": [
+                        "all"
+                    ]
+                },
+                "copy-from-recipe": {
+                    "config/": "%CONFIG_DIR%/"
+                }
+            },
+            "files": {
+                "config/packages/smr492_auth.yaml": {
+                    "contents": [
+                        "smr492_auth:",
+                        "    user_class: App\\Entity\\User",
+                        "    login_success_route: app_member_dashboard",
+                        "    registration_success_route: api_entrypoint",
+                        "    from_email: noreply@watt-werk.eu",
+                        "    from_name: WattWerk",
+                        ""
+                    ],
+                    "executable": false
+                },
+                "config/routes/smr492_auth.yaml": {
+                    "contents": [
+                        "smr492_auth:",
+                        "    resource: '@Smr492AuthBundle/src/Controller/'",
+                        "    type: attribute",
+                        ""
+                    ],
+                    "executable": false
+                }
+            },
+            "ref": "4a266bb9697d"
+        }
+    }
+}

--- a/smr492.neuro-symbolic-ai-bundle.1.0.json
+++ b/smr492.neuro-symbolic-ai-bundle.1.0.json
@@ -1,0 +1,40 @@
+{
+    "manifests": {
+        "smr492/neuro-symbolic-ai-bundle": {
+            "manifest": {
+                "bundles": {
+                    "SmR492\\NeuroSymbolicAiBundle\\NeuroSymbolicAiBundle": [
+                        "all"
+                    ]
+                },
+                "copy-from-recipe": {
+                    "config/": "%CONFIG_DIR%/"
+                }
+            },
+            "files": {
+                "config/packages/neuro_symbolic_ai.yaml": {
+                    "contents": [
+                        "neuro_symbolic_ai:",
+                        "    # Anzahl Bestätigungen, bis ein PENDING-Fakt zu CONFIRMED promotet wird.",
+                        "    # quarantine_threshold: 2",
+                        "    # Multiplikativer Faktor auf impact_score je Decay-Zyklus (0.0–1.0).",
+                        "    # decay_factor: 0.95",
+                        "    # Tage Inaktivität vor Decay.",
+                        "    # decay_interval_days: 7",
+                        "    # Maximale Iterationen des Forward-Chaining.",
+                        "    # max_inference_depth: 50",
+                        "    # Maximale Zahl jüngster Nodes im Working-Memory-Kontext.",
+                        "    # working_memory_context_limit: 20",
+                        "    # URLs/Feeds für den passiven Crawler.",
+                        "    # crawler_sources: []",
+                        "    # relayed_by-Label dieses Knotens beim nsai:graph:export (Graph-Föderation, Phase 2).",
+                        "    federation_self_peer_id: 'peer:php-local'",
+                        ""
+                    ],
+                    "executable": false
+                }
+            },
+            "ref": "2acb2e70e6fc"
+        }
+    }
+}


### PR DESCRIPTION
Behebt Issue #4: das Legacy-`manifests`-Format wurde von Flex bei konfiguriertem Endpoint ignoriert.

- `flatten.mjs` generiert aus den `smr492/<bundle>/<version>/`-Quellen das moderne Format: `index.json` (`recipes` + `_links.recipe_template_relative` + `is_contrib:false`) + Per-Recipe-JSONs mit `files`.
- README aktualisiert (Format, Flatten-Workflow, Erkenntnisse).

**End-to-End in symfony_test bewiesen:** `composer require smr492/neuro-symbolic-ai-bundle:1.0.0` → „Configuring … From github.com/SmR492/recipes" → `config/packages/neuro_symbolic_ai.yaml` wird angelegt, Bundle registriert, `cache:clear` OK, `nsai:graph:ingest/export` funktionieren.

Hinweis: Recipes matchen nur **getaggte** Releases (Dev-Branch-Installs nicht). `auth-bundle` ist mit migriert. Vor Merge auf main ggf. `node flatten.mjs main` ausführen (oder via recipe_template_relative branch-agnostisch belassen).

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)